### PR TITLE
slow5 support for testing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "slow5lib"]
+	path = slow5lib
+	url = https://github.com/hasindu2008/slow5lib

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,13 @@ CC = g++
 CFLAGS = -Wall -std=c++11 -O3 -DUSE_OPENCV_GRID_SEARCH_AUTOTRAIN -DMED_VAR
 SRCS = RawMap.cpp
 PROG = RawMap
-LIBS = -lz -lm -lstdc++ -ldl -lhdf5  -I/usr/include/opencv `pkg-config opencv --cflags --libs`
+LIBS = -lz -lm -lstdc++ -ldl  -I/usr/include/opencv -I slow5lib/include/ `pkg-config opencv --cflags --libs`
 
-$(PROG):$(SRCS)
-	$(CC) $(CFLAGS) $^ $(LIBS) -o $@
+$(PROG):$(SRCS) slow5lib/lib/libslow5.a
+	$(CC) $(CFLAGS) $^ slow5lib/lib/libslow5.a $(LIBS) -o $@
 clean:
 	-rm $(PROG)
+	make -C slow5lib clean
+
+slow5lib/lib/libslow5.a:
+	$(MAKE) -C slow5lib zstd=$(zstd) no_simd=$(no_simd) zstd_local=$(zstd_local) lib/libslow5.a

--- a/RawMap.cpp
+++ b/RawMap.cpp
@@ -8,63 +8,122 @@
 // action on each read in parallel
 //
 //#include "nanopolish_common.h"
-#include "fast5/nanopolish_fast5_io.cpp"
+//#include "fast5/nanopolish_fast5_io.cpp"
 #include <assert.h>
 #include <omp.h>
 #include <vector>
 #include <iostream>
-#include "fast5/nanopolish_fast5_loader.cpp"
+// #include "fast5/nanopolish_fast5_loader.cpp"
+#include "fast5/nanopolish_fast5_loader.h"
 #include <fstream>
 #include <string>
 #include "fast5/hjorth_params.cpp"
 #include "svm/mysvm.cpp"
+#include <slow5/slow5.h>
+
 void load_data(mySVM &s,std::string fn,int label){
 
-    std::vector<std::string> m_fast5s;
-    std::ifstream f(fn);
-    std::string line;
-    while(!f.eof()){
-     std::getline(f,line);
-     if(line.size()>0)
-     m_fast5s.push_back(line);
-    }
-    f.close();
+    // std::vector<std::string> m_fast5s;
+    // std::ifstream f(fn);
+    // std::string line;
+    // while(!f.eof()){
+    //  std::getline(f,line);
+    //  if(line.size()>0)
+    //  m_fast5s.push_back(line);
+    // }
+    // f.close();
 
-    for(size_t i = 0; i < m_fast5s.size(); ++i) {
-        fast5_file f5_file = fast5_open(m_fast5s[i]);
-        if(!fast5_is_open(f5_file)) {
-            continue;
+    //slow5tools merge can be used for merging files into one file so no need of these lists of files above
+
+    //a simple single threaded slow5 read just for testing - not for performance
+
+    slow5_file_t *sp = slow5_open(fn.c_str(),"r");
+    if(sp==NULL){
+        fprintf(stderr,"Error in opening file\n");
+        exit(1);
+    }
+
+    slow5_rec_t *rec = NULL;
+    int ret=0;
+
+    while((ret = slow5_get_next(&rec,sp)) >= 0){
+        hjorth_params H;
+        std::string read_name = rec->read_id;
+        Fast5Data data;
+        data.is_valid = true;
+        data.read_name = read_name;
+
+        // raw data
+        fast5_raw_scaling scaling;
+        scaling.digitisation = rec->digitisation;
+        scaling.offset = rec->offset;
+        scaling.range = rec->range;
+        scaling.sample_rate = rec->sampling_rate;
+
+        float *rawptr = (float*)calloc(rec->len_raw_signal, sizeof(float)); //TODO must be freed later - not sure where this rawtbl was freed in the fast5 implementation
+        raw_table rawtbl = (raw_table) { rec->len_raw_signal, 0, rec->len_raw_signal, rawptr };
+
+        float raw_unit = scaling.range / scaling.digitisation;
+        for (size_t i = 0; i < rec->len_raw_signal; i++) {
+            rawptr[i] = (rawptr[i] + scaling.offset) * raw_unit;
         }
 
-
-        std::vector<std::string> reads = fast5_get_multi_read_groups(f5_file);
-        
-        for(size_t j = 0; j < reads.size(); j++) {
-            hjorth_params H;
-	    assert(reads[j].find("read_") == 0);
-            std::string read_name = reads[j].substr(5);
-            Fast5Data data;
-            data.is_valid = true;
-            data.read_name = read_name;
-
-
-            // raw data
-            data.channel_params = fast5_get_channel_params(f5_file, read_name);
-            data.rt = fast5_get_raw_samples(f5_file, read_name, data.channel_params);
-            if(data.rt.n < MIN_LEN+TAIL) continue;
-            H.calc_hjorth(data.rt);
-	//    for(int i=0;i<data.rt.n;i++)
-	//	cout<<data.rt.raw[i]<<",";
-            //cout<<endl;
-            if(H.valid_data)
-	     s.push_data(H,label);
-	   // for(int l=0;l<H.features.size();l++)
-           // 		cout<<H.features[l]<<",";
-	   // cout<<endl;
-        }
-
-        fast5_close(f5_file);
+        data.channel_params = scaling;
+        data.rt = rawtbl;
+        if(data.rt.n < MIN_LEN+TAIL) continue;
+        H.calc_hjorth(data.rt);
+//    for(int i=0;i<data.rt.n;i++)
+//	cout<<data.rt.raw[i]<<",";
+        //cout<<endl;
+        if(H.valid_data)
+        s.push_data(H,label);
+    // for(int l=0;l<H.features.size();l++)
+        // 		cout<<H.features[l]<<",";
+    // cout<<endl;
     }
+    if(ret != SLOW5_ERR_EOF){  //check if proper end of file has been reached
+        fprintf(stderr,"Error in slow5_get_next. Error code %d\n",ret);
+        exit(1);
+    }
+    slow5_rec_free(rec);
+    slow5_close(sp);
+
+
+    // for(size_t i = 0; i < m_fast5s.size(); ++i) {
+
+    //     fast5_file f5_file = fast5_open(m_fast5s[i]);
+    //     if(!fast5_is_open(f5_file)) {
+    //         continue;
+    //     }
+
+    //     std::vector<std::string> reads = fast5_get_multi_read_groups(f5_file);
+
+    //     for(size_t j = 0; j < reads.size(); j++) {
+    //         hjorth_params H;
+	//     assert(reads[j].find("read_") == 0);
+    //         std::string read_name = reads[j].substr(5);
+    //         Fast5Data data;
+    //         data.is_valid = true;
+    //         data.read_name = read_name;
+
+
+    //         // raw data
+    //         data.channel_params = fast5_get_channel_params(f5_file, read_name);
+    //         data.rt = fast5_get_raw_samples(f5_file, read_name, data.channel_params);
+    //         if(data.rt.n < MIN_LEN+TAIL) continue;
+    //         H.calc_hjorth(data.rt);
+	// //    for(int i=0;i<data.rt.n;i++)
+	// //	cout<<data.rt.raw[i]<<",";
+    //         //cout<<endl;
+    //         if(H.valid_data)
+	//      s.push_data(H,label);
+	//    // for(int l=0;l<H.features.size();l++)
+    //        // 		cout<<H.features[l]<<",";
+	//    // cout<<endl;
+    //     }
+
+    //     fast5_close(f5_file);
+    // }
 
 }
 int main(int argc,char *argv[])
@@ -91,13 +150,13 @@ int main(int argc,char *argv[])
     load_data(s,argv[2],1);
     no=s.data.size();
     std::cout<<"DONE loading\t"<<no<< "valid target reads"<<"\n";
-      
+
     std::cout<<"#LOADING NON_TARGET READ......................\n";
     load_data(s,argv[3],0);
 
     std::cout<<"DONE loading\t"<<s.data.size()-no<< "valid non-target reads"<<"\n";
     s.test_SVM(argv);
-    
+
     }
     else{
     cout<<"ERROR in input format\n";

--- a/fast5/hjorth_params.h
+++ b/fast5/hjorth_params.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <iostream>
-#include "nanopolish_fast5_loader.h"
+//#include "nanopolish_fast5_loader.h"
+#include "event_detection.h"
+
 class hjorth_params{
 public:
 

--- a/fast5/nanopolish_fast5_io.h
+++ b/fast5/nanopolish_fast5_io.h
@@ -12,7 +12,7 @@
 
 #include <string>
 #include <vector>
-#include <hdf5.h>
+//#include <hdf5.h>
 
 extern "C" {
 #include "event_detection.h"
@@ -31,11 +31,11 @@ typedef struct {
 } fast5_raw_scaling;
 
 //
-struct fast5_file
-{
-    hid_t hdf5_file;
-    bool is_multi_fast5;
-};
+// struct fast5_file
+// {
+//     hid_t hdf5_file;
+//     bool is_multi_fast5;
+// };
 
 //
 // External API
@@ -45,55 +45,55 @@ struct fast5_file
 // Basic I/O
 //
 
-// open the file and return handle
-fast5_file fast5_open(const std::string& filename);
+// // open the file and return handle
+// fast5_file fast5_open(const std::string& filename);
 
-// check if file is open
-bool fast5_is_open(fast5_file& fh);
+// // check if file is open
+// bool fast5_is_open(fast5_file& fh);
 
-// close the file
-void fast5_close(fast5_file& fh);
+// // close the file
+// void fast5_close(fast5_file& fh);
 
 //
 // Functions to get the names of the read(s) contained in the file
 //
 
 // Get the identifier of a read from the hdf5 file (eg 00041f-....)
-std::string fast5_get_read_id_single_fast5(fast5_file& fh);
+// std::string fast5_get_read_id_single_fast5(fast5_file& fh);
 
 // Get a vector of read groups for a multi-fast5 file (eg [read_00041f-..., read_1243fe-....])
-std::vector<std::string> fast5_get_multi_read_groups(fast5_file& fh);
+// std::vector<std::string> fast5_get_multi_read_groups(fast5_file& fh);
 
 //
 // Functions to get the samples or metadata
-//
+// //
 
-// get the raw samples from this file
-raw_table fast5_get_raw_samples(fast5_file& fh, const std::string& read_id, fast5_raw_scaling scaling);
+// // get the raw samples from this file
+// raw_table fast5_get_raw_samples(fast5_file& fh, const std::string& read_id, fast5_raw_scaling scaling);
 
-// Get the sequencing kit
-std::string fast5_get_sequencing_kit(fast5_file& fh, const std::string& read_id);
+// // Get the sequencing kit
+// std::string fast5_get_sequencing_kit(fast5_file& fh, const std::string& read_id);
 
-// Get the experiment type attribute
-std::string fast5_get_experiment_type(fast5_file& fh, const std::string& read_id);
+// // Get the experiment type attribute
+// std::string fast5_get_experiment_type(fast5_file& fh, const std::string& read_id);
 
-// Get sample rate, and ADC-to-pA scalings
-fast5_raw_scaling fast5_get_channel_params(fast5_file& fh, const std::string& read_id);
+// // Get sample rate, and ADC-to-pA scalings
+// fast5_raw_scaling fast5_get_channel_params(fast5_file& fh, const std::string& read_id);
 
-// Get the start time of this read
-uint64_t fast5_get_start_time(fast5_file& fh, const std::string& read_id);
+// // Get the start time of this read
+// uint64_t fast5_get_start_time(fast5_file& fh, const std::string& read_id);
 
 //
 // Internal utility functions
 //
 
-// get the name of the raw read in the file (eg Read_1234)
-std::string fast5_get_raw_read_internal_name(fast5_file& fh);
+// // get the name of the raw read in the file (eg Read_1234)
+// std::string fast5_get_raw_read_internal_name(fast5_file& fh);
 
-// get the name of the raw read group (eg /Raw/Read/Read_1234 or /read_00041f-.../Raw/)
-std::string fast5_get_raw_read_group(fast5_file& fh, const std::string& read_id);
+// // get the name of the raw read group (eg /Raw/Read/Read_1234 or /read_00041f-.../Raw/)
+// std::string fast5_get_raw_read_group(fast5_file& fh, const std::string& read_id);
 
-//
-std::string fast5_get_string_attribute(fast5_file& fh, const std::string& group_name, const std::string& attribute_name);
+// //
+// std::string fast5_get_string_attribute(fast5_file& fh, const std::string& group_name, const std::string& attribute_name);
 
 #endif

--- a/fast5/nanopolish_fast5_loader.h
+++ b/fast5/nanopolish_fast5_loader.h
@@ -27,28 +27,28 @@ struct Fast5Data
     //uint64_t start_time;
 };
 
-class Fast5Loader
-{
-    public:
+// class Fast5Loader
+// {
+//     public:
 
-        static Fast5Data load_read(const std::string& filename, const std::string& read_name);
-        // destructor
-        ~Fast5Loader();
+//         static Fast5Data load_read(const std::string& filename, const std::string& read_name);
+//         // destructor
+//         ~Fast5Loader();
 
-    private:
+//     private:
 
-        // singleton accessor function
-        static Fast5Loader& getInstance()
-        {
-            static Fast5Loader instance;
-            return instance;
-        }
+//         // singleton accessor function
+//         static Fast5Loader& getInstance()
+//         {
+//             static Fast5Loader instance;
+//             return instance;
+//         }
 
-        Fast5Loader();
+//         Fast5Loader();
 
-        // do not allow copies of this classs
-        Fast5Loader(Fast5Loader const&) = delete;
-        void operator=(Fast5Loader const&) = delete;
-};
+//         // do not allow copies of this classs
+//         Fast5Loader(Fast5Loader const&) = delete;
+//         void operator=(Fast5Loader const&) = delete;
+// };
 
 #endif


### PR DESCRIPTION
As I had trouble getting the RawMap compiled with hdf5, I modified it to work with S/BLOW5. Had to comment out all FAST5-related stuff as I wanted to get it working fast, but you can decide, learn and implement S/BLOW support from this pull request if you like.

Note: slow5lib has been added as a submodule
so you must do a `git submodule init` and `git submodule update` and then `make`
alternatively recursively clone.

Is there a dataset that I can use to quickly verify if things are working as normal? 
I ran the training on a simulated dataset (SARS-CoV-2 vs Yeast) , which gives a result like this:
```
##TRAINING MODE
#LOADING TARGET READS.........................
DONE loading    18831valid target reads

$$$$$$$$$$$$$$$$$$$$$$$$
#LOADING NON_TARGET READ......................
DONE loading    19501valid non-target reads
Trimmmed data size: 37662
OpenCV version 2.4.9.1 (2.4.9)


Using optimal parameters degree 0.000000, gamma 0.000010, ceof0 0.000000
         C 0.100000, nu 0.000000, p 0.000000
Number of support vectors for trained SVM = 2000
Existing model file succesfully deleted
Model file created
```
Not sure if it is as expected?
